### PR TITLE
Ignore MIDI events when the browser tab isn't active

### DIFF
--- a/static/js/components/app.es6
+++ b/static/js/components/app.es6
@@ -168,9 +168,6 @@ class Layout extends React.Component {
   }
 
   onMidiMessage(message) {
-    // ignore midi events when the browser tab isn't active
-    if (document.hidden) return;
-    
     // proxy message to the current page
     if (this.refs.currentPage.onMidiMessage) {
       this.refs.currentPage.onMidiMessage(message)

--- a/static/js/components/app.es6
+++ b/static/js/components/app.es6
@@ -168,6 +168,9 @@ class Layout extends React.Component {
   }
 
   onMidiMessage(message) {
+    // ignore midi events when the browser tab isn't active
+    if (document.hidden) return;
+    
     // proxy message to the current page
     if (this.refs.currentPage.onMidiMessage) {
       this.refs.currentPage.onMidiMessage(message)

--- a/static/js/components/pages/sight_reading_page.es6
+++ b/static/js/components/pages/sight_reading_page.es6
@@ -224,7 +224,7 @@ class SightReadingPage extends React.Component {
     if (NOTE_EVENTS[type] == "noteOn") {
       if (velocity == 0) {
         this.releaseNote(n);
-      } else {
+      } else if (!document.hidden) { // ignore when the browser tab isn't active
         this.pressNote(n);
       }
     }


### PR DESCRIPTION
Includes changes for #3. These changes are untested until I can get the app running locally. Let me know if you just want to test them yourself though.