### PR TITLE
Fixed MIDI devices on iOS

### DIFF
--- a/static/js/components/app.es6
+++ b/static/js/components/app.es6
@@ -224,7 +224,13 @@ class Layout extends React.Component {
 
   midiInputs() {
     if (!this.state.midi) return;
-    return [...this.state.midi.inputs.values()];
+
+    var inputs = [];
+    var iter = this.state.midi.inputs.values();
+    for (var o = iter.next(); !o.done; o = iter.next()) {
+      inputs.push(o.value);
+    }
+    return inputs;
   }
 
   setInput(idx) {

--- a/static/js/components/device_picker_lightbox.es6
+++ b/static/js/components/device_picker_lightbox.es6
@@ -40,7 +40,13 @@ export default class DevicePickerLightbox extends Lightbox {
 
   midiInputs() {
     if (!this.props.midi) return []
-    return [...this.props.midi.inputs.values()]
+
+    var inputs = [];
+    var iter = this.props.midi.inputs.values();
+    for (var o = iter.next(); !o.done; o = iter.next()) {
+      inputs.push(o.value);
+    }
+    return inputs;
   }
 
   renderOutputPicker() {

--- a/static/js/components/midi_instrument_picker.es6
+++ b/static/js/components/midi_instrument_picker.es6
@@ -104,7 +104,13 @@ export default class MidiInstrumentPicker extends React.PureComponent {
 
   midiOutputs() {
     if (!this.props.midi) return []
-    return [...this.props.midi.outputs.values()]
+
+    var outputs = [];
+    var iter = this.props.midi.outputs.values();
+    for (var o = iter.next(); !o.done; o = iter.next()) {
+      outputs.push(o.value);
+    }
+    return outputs;
   }
 
 }


### PR DESCRIPTION
The default browser on iOS (Safari) does not have MIDI device support. Most browsers (Chrome, Opera) available on the store use the Safari engine internally, and will therefore also not support MIDI devices. There is, however, an app called [Web MIDI](https://itunes.apple.com/us/app/web-midi-browser/id953846217?mt=8). This app can load a web page on iOS with MIDI device support.

Unfortunately, this app does not seem to support using the spread operator to convert an interator to an array, which prevents it from working for this project. This PR changes these to regular for loops, which do work.

I did also test this change on Chrome, and it (somewhat unsurprisingly) continued to work fine there.

Fixes #8.